### PR TITLE
Add support for iframe <html> tags to dynamically respond to dark mode toggle

### DIFF
--- a/xsl/pretext-html.xsl
+++ b/xsl/pretext-html.xsl
@@ -9791,6 +9791,7 @@ along with MathBook XML.  If not, see <http://www.gnu.org/licenses/>.
         <xsl:call-template name="converter-blurb-html-no-date"/>
         <html>
             <xsl:call-template name="language-attributes"/>
+            <xsl:attribute name="class"/>
             <head>
                 <!-- grab the contents every iframe gets -->
                 <xsl:copy-of select="$file-wrap-iframe-head-cache"/>


### PR DESCRIPTION
This PR enables dynamic dark mode support inside iframes by modifying the `pretext-html.xsl` output template to add a `class=""` attribute to the `<html>` element in iframe HTML files.

This is especially useful for embedded JavaScript-based interactives that want to mirror the parent document’s dark mode toggle via JavaScript.